### PR TITLE
Modelの関連性について記述

### DIFF
--- a/app/models/day_article.rb
+++ b/app/models/day_article.rb
@@ -19,5 +19,5 @@
 #
 class DayArticle < ApplicationRecord
   belongs_to :user
-  has_many :habit_records
+  has_many :habit_records, dependent: :destroy
 end

--- a/app/models/day_article.rb
+++ b/app/models/day_article.rb
@@ -19,4 +19,5 @@
 #
 class DayArticle < ApplicationRecord
   belongs_to :user
+  has_many :habit_records
 end

--- a/app/models/habit.rb
+++ b/app/models/habit.rb
@@ -19,4 +19,5 @@
 #
 class Habit < ApplicationRecord
   belongs_to :user
+  has_many :habit_records
 end

--- a/app/models/habit.rb
+++ b/app/models/habit.rb
@@ -19,5 +19,5 @@
 #
 class Habit < ApplicationRecord
   belongs_to :user
-  has_many :habit_records
+  has_many :habit_records, dependent: :destroy
 end

--- a/app/models/habit_record.rb
+++ b/app/models/habit_record.rb
@@ -22,5 +22,4 @@
 class HabitRecord < ApplicationRecord
   belongs_to :habit
   belongs_to :day_article
-
 end

--- a/app/models/habit_record.rb
+++ b/app/models/habit_record.rb
@@ -22,4 +22,5 @@
 class HabitRecord < ApplicationRecord
   belongs_to :habit
   belongs_to :day_article
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,4 +36,10 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   include DeviseTokenAuth::Concerns::User
+
+  has_many :monthly_promises
+  has_many :day_articles
+  has_many :monthly_articles
+  has_many :weekly_articles
+  has_many :habits
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -37,9 +37,9 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
   include DeviseTokenAuth::Concerns::User
 
-  has_many :monthly_promises
-  has_many :day_articles
-  has_many :monthly_articles
-  has_many :weekly_articles
-  has_many :habits
+  has_many :monthly_promises, dependent: :destroy
+  has_many :day_articles, dependent: :destroy
+  has_many :monthly_articles, dependent: :destroy
+  has_many :weekly_articles, dependent: :destroy
+  has_many :habits, dependent: :destroy
 end


### PR DESCRIPTION
## 概要
先に作成したmodelに対して関連性を記述した。

従属する関連性はgコマンド時に設定できているので、has_manyの記述となった。

