### PR TITLE
habit_recordsモデルのdateを削除

### DIFF
--- a/app/models/habit_record.rb
+++ b/app/models/habit_record.rb
@@ -3,7 +3,6 @@
 # Table name: habit_records
 #
 #  id             :bigint           not null, primary key
-#  date           :date
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
 #  day_article_id :bigint           not null

--- a/db/migrate/20230914123341_remove_date_from_habit_records.rb
+++ b/db/migrate/20230914123341_remove_date_from_habit_records.rb
@@ -1,0 +1,5 @@
+class RemoveDateFromHabitRecords < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :habit_records, :date, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_14_103241) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_14_123341) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -24,7 +24,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_14_103241) do
   end
 
   create_table "habit_records", force: :cascade do |t|
-    t.date "date"
     t.bigint "habit_id", null: false
     t.bigint "day_article_id", null: false
     t.datetime "created_at", null: false


### PR DESCRIPTION
## 概要
modelの関連性を記述しているときにdateカラムが不要と判断したため削除しました。
中間テーブルとなっており、外部のidによって日付は判断できるため。