### PR TITLE
month_articleモデルのvalidation testを記述

### DIFF
--- a/app/models/monthly_article.rb
+++ b/app/models/monthly_article.rb
@@ -2,24 +2,24 @@
 #
 # Table name: monthly_articles
 #
-#  id         :bigint           not null, primary key
-#  body       :string
-#  month      :date
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  user_id    :bigint           not null
+#  id                 :bigint           not null, primary key
+#  beginning_of_month :date
+#  body               :string
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  user_id            :bigint           not null
 #
 # Indexes
 #
-#  index_monthly_articles_on_month    (month) UNIQUE
-#  index_monthly_articles_on_user_id  (user_id)
+#  index_monthly_articles_on_beginning_of_month  (beginning_of_month) UNIQUE
+#  index_monthly_articles_on_user_id             (user_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (user_id => users.id)
 #
 class MonthlyArticle < ApplicationRecord
-  validates :month, presence: true, uniqueness: true
+  validates :beginning_of_month, presence: true, uniqueness: true
   validates :body, presence: true
   belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,6 +42,5 @@ class User < ApplicationRecord
   has_many :monthly_promises, dependent: :destroy
   has_many :day_articles, dependent: :destroy
   has_many :monthly_articles, dependent: :destroy
-  has_many :weekly_articles, dependent: :destroy
   has_many :habits, dependent: :destroy
 end

--- a/db/migrate/20230926082450_rename_month_column_to_monthly_article.rb
+++ b/db/migrate/20230926082450_rename_month_column_to_monthly_article.rb
@@ -1,0 +1,5 @@
+class RenameMonthColumnToMonthlyArticle < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :monthly_articles, :month, :beginning_of_month
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_19_063926) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_26_082450) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -44,12 +44,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_19_063926) do
   end
 
   create_table "monthly_articles", force: :cascade do |t|
-    t.date "month"
+    t.date "beginning_of_month"
     t.string "body"
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["month"], name: "index_monthly_articles_on_month", unique: true
+    t.index ["beginning_of_month"], name: "index_monthly_articles_on_beginning_of_month", unique: true
     t.index ["user_id"], name: "index_monthly_articles_on_user_id"
   end
 

--- a/spec/factories/monthly_articles.rb
+++ b/spec/factories/monthly_articles.rb
@@ -2,17 +2,17 @@
 #
 # Table name: monthly_articles
 #
-#  id         :bigint           not null, primary key
-#  body       :string
-#  month      :date
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  user_id    :bigint           not null
+#  id                 :bigint           not null, primary key
+#  beginning_of_month :date
+#  body               :string
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  user_id            :bigint           not null
 #
 # Indexes
 #
-#  index_monthly_articles_on_month    (month) UNIQUE
-#  index_monthly_articles_on_user_id  (user_id)
+#  index_monthly_articles_on_beginning_of_month  (beginning_of_month) UNIQUE
+#  index_monthly_articles_on_user_id             (user_id)
 #
 # Foreign Keys
 #
@@ -20,5 +20,7 @@
 #
 FactoryBot.define do
   factory :monthly_article do
+    beginning_of_month { Faker::Date.between(from: "2020-01-01", to: "2022-12-31").beginning_of_month }
+    body { Faker::Lorem.paragraphs(number: 3).join(" ") }
   end
 end

--- a/spec/models/monthly_article_spec.rb
+++ b/spec/models/monthly_article_spec.rb
@@ -24,49 +24,47 @@ RSpec.describe MonthlyArticle, type: :model do
   context "正しく情報が指定されているとき" do
     let!(:user) { create(:user) }
     let!(:monthly_article) { build(:monthly_article, user_id: user.id) }
-    fit "記事が作成される" do
+    it "記事が作成される" do
       expect(monthly_article).to be_valid
     end
 
-    fit "記事とユーザーとの関連付けが定義されている" do
+    it "記事とユーザーとの関連付けが定義されている" do
       association = MonthlyArticle.reflect_on_association(:user)
       expect(association.macro).to eq(:belongs_to)
     end
   end
 
   # 異常系
-  context "正しく情報が指定されていない時" do
+  context "正しく情報が指定されていない時(taken)" do
     let!(:user) { create(:user) }
     let!(:monthly_article) { create(:monthly_article, user_id: user.id) }
+    let(:monthly_article_month_duplication) { build(:monthly_article, beginning_of_month: monthly_article.beginning_of_month, user_id: user.id) }
+
+    it "月が重複している時、記事が保存できない。" do
+      monthly_article_month_duplication.valid?
+      expect(monthly_article_month_duplication.errors.errors[0].type).to eq :taken
+    end
+  end
+
+  context "正しく情報が指定されていない時(blank)" do
+    let!(:user) { create(:user) }
     let(:monthly_article_user_blank) { build(:monthly_article) }
     let(:monthly_article_body_blank) { build(:monthly_article, body: "", user_id: user.id) }
     let(:monthly_article_month_blank) { build(:monthly_article, beginning_of_month: "", user_id: user.id) }
-    let(:monthly_article_month_duplication) { build(:monthly_article, beginning_of_month: monthly_article.beginning_of_month, user_id: user.id) }
-    fit "ユーザーがない時記事が作成されない" do
-      expect(monthly_article_user_blank).not_to be_valid
-      expect(monthly_article_user_blank.errors.errors[0].attribute).to eq :user
+
+    it "ユーザーがない時記事が作成されない" do
+      monthly_article_user_blank.valid?
       expect(monthly_article_user_blank.errors.errors[0].type).to eq :blank
     end
 
-    fit "日付がない時記事が作成されない" do
-      expect(monthly_article_month_blank).not_to be_valid
-      expect(monthly_article_month_blank.errors.errors[0].attribute).to eq :beginning_of_month
+    it "日付がない時記事が作成されない" do
+      monthly_article_month_blank.valid?
       expect(monthly_article_month_blank.errors.errors[0].type).to eq :blank
     end
 
-    fit "本文がない時記事が作成されない" do
-      expect(monthly_article_body_blank).not_to be_valid
-      expect(monthly_article_body_blank.errors.errors[0].attribute).to eq :body
+    it "本文がない時記事が作成されない" do
+      monthly_article_body_blank.valid?
       expect(monthly_article_body_blank.errors.errors[0].type).to eq :blank
-
     end
-
-    fit "月が重複している時、記事が保存できない。" do
-      expect(monthly_article_month_duplication).not_to be_valid
-      expect(monthly_article_month_duplication.errors.errors[0].attribute).to eq :beginning_of_month
-      expect(monthly_article_month_duplication.errors.errors[0].type).to eq :taken
-
-    end
-
   end
 end

--- a/spec/models/monthly_article_spec.rb
+++ b/spec/models/monthly_article_spec.rb
@@ -2,17 +2,17 @@
 #
 # Table name: monthly_articles
 #
-#  id         :bigint           not null, primary key
-#  body       :string
-#  month      :date
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  user_id    :bigint           not null
+#  id                 :bigint           not null, primary key
+#  beginning_of_month :date
+#  body               :string
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  user_id            :bigint           not null
 #
 # Indexes
 #
-#  index_monthly_articles_on_month    (month) UNIQUE
-#  index_monthly_articles_on_user_id  (user_id)
+#  index_monthly_articles_on_beginning_of_month  (beginning_of_month) UNIQUE
+#  index_monthly_articles_on_user_id             (user_id)
 #
 # Foreign Keys
 #
@@ -21,5 +21,52 @@
 require "rails_helper"
 
 RSpec.describe MonthlyArticle, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  context "正しく情報が指定されているとき" do
+    let!(:user) { create(:user) }
+    let!(:monthly_article) { build(:monthly_article, user_id: user.id) }
+    fit "記事が作成される" do
+      expect(monthly_article).to be_valid
+    end
+
+    fit "記事とユーザーとの関連付けが定義されている" do
+      association = MonthlyArticle.reflect_on_association(:user)
+      expect(association.macro).to eq(:belongs_to)
+    end
+  end
+
+  # 異常系
+  context "正しく情報が指定されていない時" do
+    let!(:user) { create(:user) }
+    let!(:monthly_article) { create(:monthly_article, user_id: user.id) }
+    let(:monthly_article_user_blank) { build(:monthly_article) }
+    let(:monthly_article_body_blank) { build(:monthly_article, body: "", user_id: user.id) }
+    let(:monthly_article_month_blank) { build(:monthly_article, beginning_of_month: "", user_id: user.id) }
+    let(:monthly_article_month_duplication) { build(:monthly_article, beginning_of_month: monthly_article.beginning_of_month, user_id: user.id) }
+    fit "ユーザーがない時記事が作成されない" do
+      expect(monthly_article_user_blank).not_to be_valid
+      expect(monthly_article_user_blank.errors.errors[0].attribute).to eq :user
+      expect(monthly_article_user_blank.errors.errors[0].type).to eq :blank
+    end
+
+    fit "日付がない時記事が作成されない" do
+      expect(monthly_article_month_blank).not_to be_valid
+      expect(monthly_article_month_blank.errors.errors[0].attribute).to eq :beginning_of_month
+      expect(monthly_article_month_blank.errors.errors[0].type).to eq :blank
+    end
+
+    fit "本文がない時記事が作成されない" do
+      expect(monthly_article_body_blank).not_to be_valid
+      expect(monthly_article_body_blank.errors.errors[0].attribute).to eq :body
+      expect(monthly_article_body_blank.errors.errors[0].type).to eq :blank
+
+    end
+
+    fit "月が重複している時、記事が保存できない。" do
+      expect(monthly_article_month_duplication).not_to be_valid
+      expect(monthly_article_month_duplication.errors.errors[0].attribute).to eq :beginning_of_month
+      expect(monthly_article_month_duplication.errors.errors[0].type).to eq :taken
+
+    end
+
+  end
 end


### PR DESCRIPTION
## 概要
month_articleモデルのテストを記述、および関連した修正を行いました。

## 内容
### 関連した修正
・monthをbeginning_of_monthに変更
月の重複判定のため、データベースに格納できる月の情報は一つが望ましいため制限をかけました。
例:2023/9/5や2023/9/10など入ると判定が大変。
それをその月の一番最初の日付を入れることで重複判定が容易になります。

### モデルテスト
以下のことをテストしています
正常系
・正しく情報が指定されているときmonth_articleが作成される
・month_articleとuserの関連づけがされているかの検証

異常系
・user_id,body,beginning_of_monthが空白の時month_articleが作成されない
・beginning_of_monthが重複している時、month_articleが作成されない
