### PR TITLE
monthly_promiseのModelvalidationtestを記述

### DIFF
--- a/app/models/monthly_promise.rb
+++ b/app/models/monthly_promise.rb
@@ -2,25 +2,25 @@
 #
 # Table name: monthly_promises
 #
-#  id           :bigint           not null, primary key
-#  body         :string
-#  if_then_plan :string
-#  month        :date
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
-#  user_id      :bigint           not null
+#  id                 :bigint           not null, primary key
+#  beginning_of_month :date
+#  body               :string
+#  if_then_plan       :string
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  user_id            :bigint           not null
 #
 # Indexes
 #
-#  index_monthly_promises_on_month    (month) UNIQUE
-#  index_monthly_promises_on_user_id  (user_id)
+#  index_monthly_promises_on_beginning_of_month  (beginning_of_month) UNIQUE
+#  index_monthly_promises_on_user_id             (user_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (user_id => users.id)
 #
 class MonthlyPromise < ApplicationRecord
-  validates :month, presence: true, uniqueness: true
+  validates :beginning_of_month, presence: true, uniqueness: true
   validates :body, presence: true
   validates :if_then_plan, presence: true
 

--- a/db/migrate/20230927031354_rename_month_column_to_monthly_promise.rb
+++ b/db/migrate/20230927031354_rename_month_column_to_monthly_promise.rb
@@ -1,0 +1,5 @@
+class RenameMonthColumnToMonthlyPromise < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :monthly_promises, :month, :beginning_of_month
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_26_082450) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_27_031354) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -54,13 +54,13 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_26_082450) do
   end
 
   create_table "monthly_promises", force: :cascade do |t|
-    t.date "month"
+    t.date "beginning_of_month"
     t.string "body"
     t.string "if_then_plan"
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["month"], name: "index_monthly_promises_on_month", unique: true
+    t.index ["beginning_of_month"], name: "index_monthly_promises_on_beginning_of_month", unique: true
     t.index ["user_id"], name: "index_monthly_promises_on_user_id"
   end
 

--- a/spec/factories/monthly_promises.rb
+++ b/spec/factories/monthly_promises.rb
@@ -2,18 +2,18 @@
 #
 # Table name: monthly_promises
 #
-#  id           :bigint           not null, primary key
-#  body         :string
-#  if_then_plan :string
-#  month        :date
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
-#  user_id      :bigint           not null
+#  id                 :bigint           not null, primary key
+#  beginning_of_month :date
+#  body               :string
+#  if_then_plan       :string
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  user_id            :bigint           not null
 #
 # Indexes
 #
-#  index_monthly_promises_on_month    (month) UNIQUE
-#  index_monthly_promises_on_user_id  (user_id)
+#  index_monthly_promises_on_beginning_of_month  (beginning_of_month) UNIQUE
+#  index_monthly_promises_on_user_id             (user_id)
 #
 # Foreign Keys
 #
@@ -21,5 +21,8 @@
 #
 FactoryBot.define do
   factory :monthly_promise do
+    beginning_of_month { Faker::Date.between(from: "2020-01-01", to: "2022-12-31").beginning_of_month }
+    body { Faker::Lorem.paragraphs(number: 2).join(" ") }
+    if_then_plan { Faker::Lorem.paragraphs(number: 2).join(" ") }
   end
 end

--- a/spec/models/day_article_spec.rb
+++ b/spec/models/day_article_spec.rb
@@ -35,21 +35,35 @@ RSpec.describe DayArticle, type: :model do
   end
 
   # 異常系
-  context "正しく情報が指定されていない時" do
+  context "正しく情報が指定されていない時(taken)" do
+    let!(:user) { create(:user) }
+    let!(:day_article) { create(:day_article, user_id: user.id) }
+    let(:day_article_month_duplication) { build(:day_article, day: day_article.day, user_id: user.id) }
+
+    it "日付が重複している時、記事が保存できない。" do
+      day_article_month_duplication.valid?
+      expect(day_article_month_duplication.errors.errors[0].type).to eq :taken
+    end
+  end
+
+  context "正しく情報が指定されていない時()" do
     let!(:user) { create(:user) }
     let(:day_article_user_blank) { build(:day_article) }
     let(:day_article_body_blank) { build(:day_article, body: "", user_id: user.id) }
     let(:day_article_day_blank) { build(:day_article, day: "", user_id: user.id) }
     it "ユーザーがない時記事が作成されない" do
-      expect(day_article_user_blank).not_to be_valid
+      day_article_user_blank.valid?
+      expect(day_article_user_blank.errors.errors[0].type).to eq :blank
     end
 
     it "日付がない時記事が作成されない" do
-      expect(day_article_day_blank).not_to be_valid
+      day_article_day_blank.valid?
+      expect(day_article_day_blank.errors.errors[0].type).to eq :blank
     end
 
     it "本文がない時記事が作成されない" do
-      expect(day_article_body_blank).not_to be_valid
+      day_article_body_blank.valid?
+      expect(day_article_body_blank.errors.errors[0].type).to eq :blank
     end
   end
 end

--- a/spec/models/monthly_promise_spec.rb
+++ b/spec/models/monthly_promise_spec.rb
@@ -2,18 +2,18 @@
 #
 # Table name: monthly_promises
 #
-#  id           :bigint           not null, primary key
-#  body         :string
-#  if_then_plan :string
-#  month        :date
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
-#  user_id      :bigint           not null
+#  id                 :bigint           not null, primary key
+#  beginning_of_month :date
+#  body               :string
+#  if_then_plan       :string
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  user_id            :bigint           not null
 #
 # Indexes
 #
-#  index_monthly_promises_on_month    (month) UNIQUE
-#  index_monthly_promises_on_user_id  (user_id)
+#  index_monthly_promises_on_beginning_of_month  (beginning_of_month) UNIQUE
+#  index_monthly_promises_on_user_id             (user_id)
 #
 # Foreign Keys
 #
@@ -22,5 +22,57 @@
 require "rails_helper"
 
 RSpec.describe MonthlyPromise, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  context "正しく情報が指定されているとき" do
+    let!(:user) { create(:user) }
+    let!(:monthly_promise) { build(:monthly_promise, user_id: user.id) }
+    fit "記事が作成される" do
+      expect(monthly_promise).to be_valid
+    end
+
+    fit "月の約束事とユーザーとの関連付けが定義されている" do
+      association = MonthlyPromise.reflect_on_association(:user)
+      expect(association.macro).to eq(:belongs_to)
+    end
+  end
+
+  # 異常系
+  context "正しく情報が指定されていない時(taken)" do
+    let!(:user) { create(:user) }
+    let!(:monthly_promise) { create(:monthly_promise, user_id: user.id) }
+    let(:monthly_promise_month_duplication) { build(:monthly_promise, beginning_of_month: monthly_promise.beginning_of_month, user_id: user.id) }
+
+    it "月が重複している時、記事が保存できない。" do
+      monthly_promise_month_duplication.valid?
+      expect(monthly_promise_month_duplication.errors.errors[0].type).to eq :taken
+    end
+  end
+
+  context "正しく情報が指定されていない時(blank)" do
+    let!(:user) { create(:user) }
+    let(:monthly_promise_user_blank) { build(:monthly_promise) }
+    let(:monthly_promise_body_blank) { build(:monthly_promise, body: "", user_id: user.id) }
+    let(:monthly_promise_if_then_plan_blank) { build(:monthly_promise, if_then_plan: "", user_id: user.id) }
+    let(:monthly_promise_month_blank) { build(:monthly_promise, beginning_of_month: "", user_id: user.id) }
+
+    fit "ユーザーがない時記事が作成されない" do
+      monthly_promise_user_blank.valid?
+      expect(monthly_promise_user_blank.errors.errors[0].type).to eq :blank
+    end
+
+    fit "日付がない時記事が作成されない" do
+      monthly_promise_month_blank.valid?
+      expect(monthly_promise_month_blank.errors.errors[0].type).to eq :blank
+    end
+
+    fit "本文がない時記事が作成されない" do
+      monthly_promise_body_blank.valid?
+      expect(monthly_promise_body_blank.errors.errors[0].type).to eq :blank
+    end
+
+    fit "対策がない時記事が作成されない" do
+      monthly_promise_if_then_plan_blank.valid?
+      expect(monthly_promise_if_then_plan_blank.errors.errors[0].type).to eq :blank
+    end
+  end
+
 end

--- a/spec/models/monthly_promise_spec.rb
+++ b/spec/models/monthly_promise_spec.rb
@@ -25,11 +25,11 @@ RSpec.describe MonthlyPromise, type: :model do
   context "正しく情報が指定されているとき" do
     let!(:user) { create(:user) }
     let!(:monthly_promise) { build(:monthly_promise, user_id: user.id) }
-    fit "記事が作成される" do
+    it "記事が作成される" do
       expect(monthly_promise).to be_valid
     end
 
-    fit "月の約束事とユーザーとの関連付けが定義されている" do
+    it "月の約束事とユーザーとの関連付けが定義されている" do
       association = MonthlyPromise.reflect_on_association(:user)
       expect(association.macro).to eq(:belongs_to)
     end
@@ -54,25 +54,24 @@ RSpec.describe MonthlyPromise, type: :model do
     let(:monthly_promise_if_then_plan_blank) { build(:monthly_promise, if_then_plan: "", user_id: user.id) }
     let(:monthly_promise_month_blank) { build(:monthly_promise, beginning_of_month: "", user_id: user.id) }
 
-    fit "ユーザーがない時記事が作成されない" do
+    it "ユーザーがない時記事が作成されない" do
       monthly_promise_user_blank.valid?
       expect(monthly_promise_user_blank.errors.errors[0].type).to eq :blank
     end
 
-    fit "日付がない時記事が作成されない" do
+    it "日付がない時記事が作成されない" do
       monthly_promise_month_blank.valid?
       expect(monthly_promise_month_blank.errors.errors[0].type).to eq :blank
     end
 
-    fit "本文がない時記事が作成されない" do
+    it "本文がない時記事が作成されない" do
       monthly_promise_body_blank.valid?
       expect(monthly_promise_body_blank.errors.errors[0].type).to eq :blank
     end
 
-    fit "対策がない時記事が作成されない" do
+    it "対策がない時記事が作成されない" do
       monthly_promise_if_then_plan_blank.valid?
       expect(monthly_promise_if_then_plan_blank.errors.errors[0].type).to eq :blank
     end
   end
-
 end


### PR DESCRIPTION
## 概要
monthly_promiseのテストの作成、
day_articleモデルのテストのリファクタリングを行いました。

## 内容
### monthly_promiseのテストの作成
monthly_articlesもテストを基に作成しました。

・monthカラムをbeginning_of_monthに変更
・if_then_planの空白の場合のテストを追加

### day_articleモデルのテストのリファクタリング
マッチャーが全てbe_validで判定になっていたので、blankかtakenなのかなどを確認するようにしました。

※[userモデルのテストの修正](https://github.com/yoshi-nip/my_partner_rails/pull/15/commits/1ffd337cfffaa495e09f64aec203069eed2ce3e1)
こちらのコミットメッセージですが、誤りです。
正しくはday_articleモデルのテストの修正です。
