### PR TITLE
habitモデルのテストを作成

### DIFF
--- a/app/models/habit.rb
+++ b/app/models/habit.rb
@@ -11,16 +11,16 @@
 #
 # Indexes
 #
-#  index_habits_on_start_date  (start_date) UNIQUE
-#  index_habits_on_user_id     (user_id)
+#  index_habits_on_name     (name) UNIQUE
+#  index_habits_on_user_id  (user_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (user_id => users.id)
 #
 class Habit < ApplicationRecord
-  validates :start_date, presence: true, uniqueness: true
-  validates :body, presence: true
+  validates :start_date, presence: true
+  validates :name, presence: true, uniqueness: true
 
   belongs_to :user
   has_many :habit_records, dependent: :destroy

--- a/db/migrate/20230927035909_add_index_to_habits.rb
+++ b/db/migrate/20230927035909_add_index_to_habits.rb
@@ -1,0 +1,5 @@
+class AddIndexToHabits < ActiveRecord::Migration[7.0]
+  def change
+    add_index :habits, :name, unique: true
+  end
+end

--- a/db/migrate/20230927040259_remove_index_from_habits.rb
+++ b/db/migrate/20230927040259_remove_index_from_habits.rb
@@ -1,0 +1,5 @@
+class RemoveIndexFromHabits < ActiveRecord::Migration[7.0]
+  def change
+    remove_index :habits, :start_date, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_27_031354) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_27_040259) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -39,7 +39,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_27_031354) do
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["start_date"], name: "index_habits_on_start_date", unique: true
+    t.index ["name"], name: "index_habits_on_name", unique: true
     t.index ["user_id"], name: "index_habits_on_user_id"
   end
 

--- a/spec/factories/habits.rb
+++ b/spec/factories/habits.rb
@@ -11,8 +11,8 @@
 #
 # Indexes
 #
-#  index_habits_on_start_date  (start_date) UNIQUE
-#  index_habits_on_user_id     (user_id)
+#  index_habits_on_name     (name) UNIQUE
+#  index_habits_on_user_id  (user_id)
 #
 # Foreign Keys
 #
@@ -20,5 +20,7 @@
 #
 FactoryBot.define do
   factory :habit do
+    name { Faker::Hobby.activity }
+    start_date { Faker::Date.between(from: "2020-01-01", to: "2022-12-31") }
   end
 end

--- a/spec/models/day_article_spec.rb
+++ b/spec/models/day_article_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe DayArticle, type: :model do
   context "正しく情報が指定されているとき" do
     let!(:user) { create(:user) }
     let!(:day_article) { build(:day_article, user_id: user.id) }
-    it "ユーザーが作成される" do
+    it "記事が作成される" do
       expect(day_article).to be_valid
     end
 

--- a/spec/models/habit_spec.rb
+++ b/spec/models/habit_spec.rb
@@ -11,8 +11,8 @@
 #
 # Indexes
 #
-#  index_habits_on_start_date  (start_date) UNIQUE
-#  index_habits_on_user_id     (user_id)
+#  index_habits_on_name     (name) UNIQUE
+#  index_habits_on_user_id  (user_id)
 #
 # Foreign Keys
 #
@@ -21,5 +21,49 @@
 require "rails_helper"
 
 RSpec.describe Habit, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  context "正しく情報が指定されているとき" do
+    let!(:user) { create(:user) }
+    let!(:habit) { build(:habit, user_id: user.id) }
+    it "習慣が作成される" do
+      expect(habit).to be_valid
+    end
+
+    it "ユーザーとの関連付けが定義されている" do
+      association = Habit.reflect_on_association(:user)
+      expect(association.macro).to eq(:belongs_to)
+    end
+  end
+
+  # 異常系
+  context "正しく情報が指定されていない時(taken)" do
+    let!(:user) { create(:user) }
+    let!(:habit) { create(:habit, user_id: user.id) }
+    let(:habit_name_duplication) { build(:habit, name: habit.name, user_id: user.id) }
+
+    it "名前が重複している時、記事が保存できない。" do
+      habit_name_duplication.valid?
+      expect(habit_name_duplication.errors.errors[0].type).to eq :taken
+    end
+  end
+
+  context "正しく情報が指定されていない時()" do
+    let!(:user) { create(:user) }
+    let(:habit_user_blank) { build(:habit) }
+    let(:habit_name_blank) { build(:habit, name: "", user_id: user.id) }
+    let(:habit_start_date_blank) { build(:habit, start_date: "", user_id: user.id) }
+    it "ユーザーがない時記事が作成されない" do
+      habit_user_blank.valid?
+      expect(habit_user_blank.errors.errors[0].type).to eq :blank
+    end
+
+    it "開始日がない時記事が作成されない" do
+      habit_start_date_blank.valid?
+      expect(habit_start_date_blank.errors.errors[0].type).to eq :blank
+    end
+
+    it "本文がない時記事が作成されない" do
+      habit_name_blank.valid?
+      expect(habit_name_blank.errors.errors[0].type).to eq :blank
+    end
+  end
 end


### PR DESCRIPTION
## 概要
・habitモデルのテストを作成（day_articleを参考に）
・habitモデルのカラムのユニーク制約と空白の制約を修正しました
・day_articleに誤字があったため修正しています。

## 内容
### habitモデルのテストを作成（day_articleを参考に）
以下の内容を確認しています。

正常系
・正しい時habitが作成できること
・userとの関連づけがされていること

異常系
・nameの重複がある時habitが作成できないこと
・user_id,name,start_dateが空白の時habitが作成できないこと

### habitモデルのカラムのユニーク制約と空白の制約を修正
・nameに重複はよくないためこちらをユニーク制約に
・start_dateはかぶることもあるためユニーク制約を解除