### PR TITLE
habit_recordモデルのテストを作成

### DIFF
--- a/spec/factories/habit_records.rb
+++ b/spec/factories/habit_records.rb
@@ -20,5 +20,7 @@
 #
 FactoryBot.define do
   factory :habit_record do
+    habit
+    day_article
   end
 end

--- a/spec/factories/habits.rb
+++ b/spec/factories/habits.rb
@@ -22,5 +22,6 @@ FactoryBot.define do
   factory :habit do
     name { Faker::Hobby.activity }
     start_date { Faker::Date.between(from: "2020-01-01", to: "2022-12-31") }
+    user
   end
 end

--- a/spec/models/habit_record_spec.rb
+++ b/spec/models/habit_record_spec.rb
@@ -21,5 +21,41 @@
 require "rails_helper"
 
 RSpec.describe HabitRecord, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let!(:habit) { create(:habit) }
+  let!(:day_article) { create(:day_article, user_id: habit.user.id) }
+  let(:habit_record) { create(:habit_record, habit_id: habit.id, day_article_id: day_article.id) }
+  let!(:habit_record_day_article_blank) { build(:habit_record, habit_id: habit.id, day_article_id: "") }
+  let!(:habit_record_habit_blank) { build(:habit_record, habit_id: "", day_article_id: day_article.id) }
+
+  context "正常な関連づけがされている" do
+    it "日記との関連付けが定義されていることを確認" do
+      association = HabitRecord.reflect_on_association(:day_article)
+      expect(association.macro).to eq(:belongs_to)
+    end
+
+    it "習慣との関連付けが定義されていることを確認" do
+      association = HabitRecord.reflect_on_association(:habit)
+      expect(association.macro).to eq(:belongs_to)
+    end
+
+    it "habit_recordからday_articleの値が取得できる" do
+      expect(habit_record.day_article).to eq(day_article)
+    end
+
+    it "habit_recordからhabitの値が取得できる" do
+      expect(habit_record.habit).to eq(habit)
+    end
+  end
+
+  context "正常な関連付けがない場合" do
+    it "day_article_idがない時レコードが作成されない" do
+      habit_record_day_article_blank.valid?
+      expect(habit_record_day_article_blank.errors.errors[0].type).to eq :blank
+    end
+
+    it "habit_idがない時レコードが作成されない" do
+      habit_record_habit_blank.valid?
+      expect(habit_record_habit_blank.errors.errors[0].type).to eq :blank
+    end
+  end
 end

--- a/spec/models/habit_spec.rb
+++ b/spec/models/habit_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Habit, type: :model do
 
   context "正しく情報が指定されていない時()" do
     let!(:user) { create(:user) }
-    let(:habit_user_blank) { build(:habit) }
+    let(:habit_user_blank) { build(:habit, user_id: nil) }
     let(:habit_name_blank) { build(:habit, name: "", user_id: user.id) }
     let(:habit_start_date_blank) { build(:habit, start_date: "", user_id: user.id) }
     it "ユーザーがない時記事が作成されない" do


### PR DESCRIPTION
## 概要
・habit_recordモデルのテストを作成
・上記に伴いfactorybotの内容を一部変更
##内容
### habit_recordモデルのテストを作成
以下のことをを確認
正常系
・中間テーブルのため関連付けができているかを確認
・habit_recordからday_articleとhabitの内容が取得できるかを確認

異常系
・day_article_idとhabit_idがない場合レコードが作成されないことを確認しています。

###  factorybotの内容を一部変更
・spec/factories/habit_records.rb
habitとday_articleの関連付け記述
・spec/factories/habits.rb
userとの関連付けを記述

[c1fa87d](https://github.com/yoshi-nip/my_partner_rails/pull/17/commits/c1fa87d2e11bef021c049aee95bbb84560d7d0a6)
こちらの内容は、
・spec/factories/habits.rb
userとの関連付けを記述
に起因するもので修正しています。