### PR TITLE
day_articlesのshowメソッドのテストの作成、rspec,rubocopなどのエラー対処

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,11 @@ inherit_from:
   - config/rubocop/rails.yml
   - config/rubocop/rspec.yml
 
+RSpec/MultipleExpectations:
+  Max: 10
+RSpec/ExampleLength:
+  Max: 10
+
 AllCops:
   TargetRubyVersion: 3.2
   SuggestExtensions: false

--- a/spec/factories/monthly_articles.rb
+++ b/spec/factories/monthly_articles.rb
@@ -20,7 +20,7 @@
 #
 FactoryBot.define do
   factory :monthly_article do
-    beginning_of_month { Faker::Date.between(from: "2020-01-01", to: "2022-12-31").beginning_of_month }
+    beginning_of_month { Faker::Date.between(from: "2000-01-01", to: "2022-12-31").beginning_of_month }
     body { Faker::Lorem.paragraphs(number: 3).join(" ") }
     user
   end

--- a/spec/requests/api/v1/day_articles_spec.rb
+++ b/spec/requests/api/v1/day_articles_spec.rb
@@ -30,4 +30,42 @@ RSpec.describe "Api::V1::DayArticles", type: :request do
       end
     end
   end
+
+  describe "GET/show" do
+    subject { get(api_v1_day_article_path(day_article_id)) }
+
+    let(:day_article) { create(:day_article) }
+
+    context "/api/v1/day_articles/:idのルートの時(正しい値)" do
+      let(:day_article_id) { day_article.id }
+      before do
+        subject
+      end
+
+      it "httpステータスが正常である" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "詳細を取得できる" do
+        res = JSON.parse(response.body)
+
+        expect(res.length).to eq 6
+        expect(res.keys).to eq ["id", "body", "day", "updated_at", "user_id", "user"]
+        expect(res["id"]).to eq day_article.id
+        expect(res["body"]).to eq day_article.body
+        expect(res["day"]).to eq day_article.day.strftime("%Y-%m-%d")
+        expect(res["updated_at"]).to be_present
+        expect(res["user_id"]).to eq day_article.user_id
+        expect(res["user"].keys).to eq ["id", "name", "email", "updated_at"]
+      end
+    end
+
+    context "/api/v1/day_articles/:idのルートの時(誤った値)" do
+      let(:day_article_id) { 99_999_999 }
+
+      it "httpステータスがエラーが返ってくる" do
+        expect { subject }.to raise_error ActiveRecord::RecordNotFound
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/monthly_article_spec.rb
+++ b/spec/requests/api/v1/monthly_article_spec.rb
@@ -6,7 +6,9 @@ RSpec.describe "Api::V1::MonthlyArticles", type: :request do
 
     context "/api/v1/monthly_articlesのルートの時" do
       before do
-        create_list(:monthly_article, 3)
+        3.times do |n|
+          create(:monthly_article, beginning_of_month: "2022-#{1 + n}-1")
+        end
         subject
       end
 

--- a/spec/requests/api/v1/monthly_promise_spec.rb
+++ b/spec/requests/api/v1/monthly_promise_spec.rb
@@ -6,7 +6,9 @@ RSpec.describe "Api::V1::MonthlyPromises", type: :request do
 
     context "/api/v1/monthly_promisesのルートの時" do
       before do
-        create_list(:monthly_promise, 3)
+        3.times do |n|
+          create(:monthly_article, beginning_of_month: "2022-#{1 + n}-1")
+        end
         subject
       end
 


### PR DESCRIPTION
## 概要
表題通りです。

## 内容
### day_articlesのshowメソッドのテストの作成

spec/requests/api/v1/day_articles_spec.rb

以下の内容をテストしています。
・正しいhttpコードが返っててきていること
・詳細情報が取得できること
・誤った値の時、エラーが返ってくること

### .rubocop.yml
expectの数を10は許容するように設定しています。

### spec/requests/api/v1/monthly_article_spec.rb,monthly_promise_spec.rb
月別レコードをランダムに作成ループすると重複の可能性があるため
重複しないように作成しております。