### PR TITLE
day_articleコントローラのcreateメソッド修正、テストの作成(モックの使用)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,10 @@ RSpec/MultipleExpectations:
 RSpec/ExampleLength:
   Max: 10
 
+## 開発途中での記述。開発が進み、モックが必要なくなれば解除する。
+RSpec/AnyInstance:
+  Enabled: false
+
 AllCops:
   TargetRubyVersion: 3.2
   SuggestExtensions: false

--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,2 +1,6 @@
 class Api::V1::BaseApiController < ApplicationController
+  ## 仮の実装、モック
+  def current_user
+    @current_user = User.first
+  end
 end

--- a/app/controllers/api/v1/day_articles_controller.rb
+++ b/app/controllers/api/v1/day_articles_controller.rb
@@ -6,7 +6,7 @@ class Api::V1::DayArticlesController < Api::V1::BaseApiController
   end
 
   def create
-    day_article = DayArticle.new(day_article_params)
+    day_article = current_user.day_articles.build(day_article_params)
     if day_article.save
       render json: day_article, status: :created
     else
@@ -33,4 +33,11 @@ class Api::V1::DayArticlesController < Api::V1::BaseApiController
     day_article.destroy!
     head :no_content
   end
+
+  private
+
+    # Storong Parameter
+    def day_article_params
+      params.require(:day_article).permit(:body, :day)
+    end
 end

--- a/spec/requests/api/v1/day_articles_spec.rb
+++ b/spec/requests/api/v1/day_articles_spec.rb
@@ -68,4 +68,31 @@ RSpec.describe "Api::V1::DayArticles", type: :request do
       end
     end
   end
+
+  describe "POST/create" do
+    subject { post(api_v1_day_articles_path, params: day_articles_params) }
+
+    let!(:current_user) { create(:user) }
+
+    before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+
+    context "ログインユーザーの時、適切なパラメータをもとに記事が作成される" do
+      let(:day_articles_params) { { day_article: attributes_for(:day_article) } }
+      it "現在のユーザをもとに記事が作成できる" do
+        subject
+        res = JSON.parse(response.body)
+        expect(DayArticle.last.user_id).to eq(current_user.id)
+        expect(response).to have_http_status(:created)
+        expect(res["day"]).to eq day_articles_params[:day_article][:day].strftime("%Y-%m-%d")
+        expect(res["body"]).to eq day_articles_params[:day_article][:body]
+      end
+    end
+
+    context "正しくないパラメータでリクエストを送った時" do
+      let(:day_articles_params) { attributes_for(:day_article) }
+      it "エラーになる" do
+        expect { subject }.to raise_error ActionController::ParameterMissing
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 概要
標題の通りです。

## 内容
### day_articleコントローラのcreateメソッド修正
・strong parameterを記述し、createメソッドにparamsとして渡す
・current_user(ログインユーザー)からday_articleのレコードを作成


### テストの作成(モックの使用)
・current_user、divise_token_authの細かな開発を進めていないため、仮の実装としてモックを使用
・.rubocop.ymlにはallow_any_instance_ofの仕様によってrubocopから警告が出るのを一時的に解除する記述
user機能の開発が進み次第削除予定。

以下のことをテストしています。
・day_articleレコードがcurrent_userを元に作成できる
・パラメータが間違っている時、エラーが起きる
