### PR TITLE
day_articlesコントローラのdestroyアクションの修正、テストの記述

### DIFF
--- a/app/controllers/api/v1/day_articles_controller.rb
+++ b/app/controllers/api/v1/day_articles_controller.rb
@@ -29,7 +29,7 @@ class Api::V1::DayArticlesController < Api::V1::BaseApiController
   end
 
   def destroy
-    day_article = DayArticle.find(params[:id])
+    day_article = current_user.day_articles.find(params[:id])
     day_article.destroy!
     head :no_content
   end

--- a/spec/requests/api/v1/day_articles_spec.rb
+++ b/spec/requests/api/v1/day_articles_spec.rb
@@ -126,6 +126,7 @@ RSpec.describe "Api::V1::DayArticles", type: :request do
 
   describe "DELETE /destroy" do
     subject { delete(api_v1_day_article_path(day_article)) }
+
     let!(:day_article) { create(:day_article, user: current_user) }
     let!(:current_user) { create(:user) }
 
@@ -136,7 +137,7 @@ RSpec.describe "Api::V1::DayArticles", type: :request do
         # リクエストを送信
         subject
         # HTTPステータスが正常なことを検証　204-deleteやput時に返ってくることのあるステータスz
-        expect(response).to have_http_status(204)
+        expect(response).to have_http_status(:no_content)
         # データベース上で記事が削除されたことを検証
         expect(DayArticle.find_by(id: day_article.id)).to be_nil
       end

--- a/spec/requests/api/v1/day_articles_spec.rb
+++ b/spec/requests/api/v1/day_articles_spec.rb
@@ -123,4 +123,23 @@ RSpec.describe "Api::V1::DayArticles", type: :request do
       end
     end
   end
+
+  describe "DELETE /destroy" do
+    subject { delete(api_v1_day_article_path(day_article)) }
+    let!(:day_article) { create(:day_article, user: current_user) }
+    let!(:current_user) { create(:user) }
+
+    before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+
+    context "ログインユーザーの場合、記事が削除される" do
+      it "現在のユーザをもとに記事が削除される" do
+        # リクエストを送信
+        subject
+        # HTTPステータスが正常なことを検証　204-deleteやput時に返ってくることのあるステータスz
+        expect(response).to have_http_status(204)
+        # データベース上で記事が削除されたことを検証
+        expect(DayArticle.find_by(id: day_article.id)).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 概要
表題の通りです。

## 内容

### app/controllers/api/v1/day_articles_controller.rb
current_userを元にday_articlesの任意のidのレコードを取り出し、削除しています。

### spec/requests/api/v1/day_articles_spec.rb
リクエストを送り、送信後、データが削除されていることを確認しています。
ステータスは204,no_contentをなことを確認しています。