### PR TITLE
user新規登録機能の作成、テストの作成

### DIFF
--- a/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/app/controllers/api/v1/auth/registrations_controller.rb
@@ -1,5 +1,6 @@
 class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsController
   private
+
     def sign_up_params
       params.require(:registration).permit(:name, :email, :password, :password_confirmation)
     end

--- a/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/app/controllers/api/v1/auth/registrations_controller.rb
@@ -1,0 +1,10 @@
+class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsController
+  private
+    def sign_up_params
+      params.require(:registration).permit(:name, :email, :password, :password_confirmation)
+    end
+
+    def account_update_params
+      params.require(:user).permit(:name, :email)
+    end
+end

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -5,7 +5,7 @@ DeviseTokenAuth.setup do |config|
   # client is responsible for keeping track of the changing tokens. Change
   # this to false to prevent the Authorization header from changing after
   # each request.
-  # config.change_headers_on_each_request = true
+  config.change_headers_on_each_request = false
 
   # By default, users will need to re-authenticate after 2 weeks. This setting
   # determines how long tokens will remain valid after they are issued.
@@ -42,14 +42,14 @@ DeviseTokenAuth.setup do |config|
   # config.default_callbacks = true
 
   # Makes it possible to change the headers names
-  # config.headers_names = {
-  #   :'authorization' => 'Authorization',
-  #   :'access-token' => 'access-token',
-  #   :'client' => 'client',
-  #   :'expiry' => 'expiry',
-  #   :'uid' => 'uid',
-  #   :'token-type' => 'token-type'
-  # }
+  config.headers_names = {
+    'authorization': "Authorization",
+    'access-token': "access-token",
+    'client': "client",
+    'expiry': "expiry",
+    'uid': "uid",
+    'token-type': "token-type",
+  }
 
   # Makes it possible to use custom uid column
   # config.other_uid = "foo"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,13 @@
 Rails.application.routes.draw do
-  mount_devise_token_auth_for "User", at: "auth"
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Defines the root path route ("/")
   # root "articles#index"
   namespace :api do
     namespace :v1 do
+      mount_devise_token_auth_for "User", at: "auth", controllers: {
+        registrations: "api/v1/auth/registrations",
+      }
       resources :day_articles, only: [:index, :create, :show, :update, :destroy]
       resources :monthly_articles, only: [:index, :create, :show, :update, :destroy]
       resources :monthly_promises, only: [:index, :create, :show, :update, :destroy]

--- a/spec/requests/api/v1/auth/registrations_spec.rb
+++ b/spec/requests/api/v1/auth/registrations_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::Auth::Registrations", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/spec/requests/api/v1/auth/registrations_spec.rb
+++ b/spec/requests/api/v1/auth/registrations_spec.rb
@@ -1,7 +1,27 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe "Api::V1::Auth::Registrations", type: :request do
-  describe "GET /index" do
-    pending "add some examples (or delete) #{__FILE__}"
+  describe "POST /api/v1/auth" do
+    subject { post(api_v1_user_registration_path, params: user_params) }
+
+    context "適切なパラメータが送信されたとき" do
+      let(:user_params) { { registration: attributes_for(:user) } }
+      it "新規ユーザーが作られる" do
+        expect { subject }.to change { User.count }.by(1)
+        res = JSON.parse(response.body)
+        expect(res["status"]).to eq "success"
+        expect(res["data"]["name"]).to eq user_params[:registration][:name]
+        expect(res["data"]["email"]).to eq user_params[:registration][:email]
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "想定したヘッダー情報が返ってくる" do
+        subject
+        expected_headers = ["token-type", "access-token", "client", "uid", "expiry", "authorization"]
+        expected_headers.each do |header_key|
+          expect(response.header[header_key]).to be_present
+        end
+      end
+    end
   end
 end

--- a/spec/requests/api/v1/auth/registrations_spec.rb
+++ b/spec/requests/api/v1/auth/registrations_spec.rb
@@ -3,7 +3,8 @@ require "rails_helper"
 RSpec.describe "Api::V1::Auth::Registrations", type: :request do
   describe "POST /api/v1/auth" do
     subject { post(api_v1_user_registration_path, params: user_params) }
-    #正常系
+
+    # 正常系
     context "適切なパラメータが送信されたとき" do
       let(:user_params) { { registration: attributes_for(:user) } }
       it "新規ユーザーが作られる" do
@@ -24,7 +25,7 @@ RSpec.describe "Api::V1::Auth::Registrations", type: :request do
       end
     end
 
-    #異常系
+    # 異常系
     context "不適切なパラメータが送れた時" do
       let(:user_params) { attributes_for(:user) }
       it "エラーが返ってくる" do

--- a/spec/requests/api/v1/auth/registrations_spec.rb
+++ b/spec/requests/api/v1/auth/registrations_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "Api::V1::Auth::Registrations", type: :request do
   describe "POST /api/v1/auth" do
     subject { post(api_v1_user_registration_path, params: user_params) }
-
+    #正常系
     context "適切なパラメータが送信されたとき" do
       let(:user_params) { { registration: attributes_for(:user) } }
       it "新規ユーザーが作られる" do
@@ -15,12 +15,44 @@ RSpec.describe "Api::V1::Auth::Registrations", type: :request do
         expect(response).to have_http_status(:ok)
       end
 
-      it "想定したヘッダー情報が返ってくる" do
+      it "想定したtokenのヘッダー情報が返ってくる" do
         subject
         expected_headers = ["token-type", "access-token", "client", "uid", "expiry", "authorization"]
         expected_headers.each do |header_key|
           expect(response.header[header_key]).to be_present
         end
+      end
+    end
+
+    #異常系
+    context "不適切なパラメータが送れた時" do
+      let(:user_params) { attributes_for(:user) }
+      it "エラーが返ってくる" do
+        expect { subject }.to raise_error ActionController::ParameterMissing
+      end
+    end
+
+    context "nameがない時" do
+      let(:user_params) { { registration: attributes_for(:user, name: nil) } }
+      it "エラーが返ってくる" do
+        subject
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context "emailがない時" do
+      let(:user_params) { { registration: attributes_for(:user, email: nil) } }
+      it "エラーが返ってくる" do
+        subject
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context "passwordがない時" do
+      let(:user_params) { { registration: attributes_for(:user, password: nil) } }
+      it "エラーが返ってくる" do
+        subject
+        expect(response).to have_http_status(:unprocessable_entity)
       end
     end
   end


### PR DESCRIPTION
## 概要
app/controllers/api/v1/auth/registrations_controller.rb
・user新規登録機能の作成、テストの作成
・divise-token-authの設定の修正
・strong parameterのオーバーライド

## 内容

### user新規登録機能の作成
config/routes.rbのルーティングでdivise-token-authの機能を使えるように記述

### テストの作成
spec/requests/api/v1/auth/registrations_spec.rb

以下のことをテストしてます。
正常系
・ユーザーが新規作成される
・想定したtoken情報が返ってくる

異常系
・不適切な形のパラメータの際、エラーが返ってくる
・name,email,passwordが空白の時、エラーが返ってくる

### divise-token-authの設定の修正
'config.change_headers_on_each_request = false`
リクエストのたび認証tokenが変更されることをOFFにしました。

ヘッダー情報の名前をコメントアウトしました。

### app/controllers/api/v1/auth/registrations_controller.rb
オーバーライド、更新の方も記述をしておきました。