### PR TITLE
ログアウト機能のテストの実装

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,10 +14,6 @@ RSpec/ExampleLength:
 ## 開発途中での記述。開発が進み、モックが必要なくなれば解除する。
 RSpec/AnyInstance:
   Enabled: false
-## let！の規制を緩める
-RSpec/LetSetup:
-  Enabled: true
-
 AllCops:
   TargetRubyVersion: 3.2
   SuggestExtensions: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,9 @@ RSpec/ExampleLength:
 ## 開発途中での記述。開発が進み、モックが必要なくなれば解除する。
 RSpec/AnyInstance:
   Enabled: false
+## let！の規制を緩める
+RSpec/LetSetup:
+  Enabled: true
 
 AllCops:
   TargetRubyVersion: 3.2

--- a/config/application.rb
+++ b/config/application.rb
@@ -39,5 +39,9 @@ module MyPartnerRails
     config.generators do |g|
       g.test_framework :rspec
     end
+
+    config.session_store :cookie_store, key: "_interslice_session"
+    config.middleware.use ActionDispatch::Cookies
+    config.middleware.use config.session_store, config.session_options
   end
 end

--- a/spec/requests/api/v1/auth/sessions_spec.rb
+++ b/spec/requests/api/v1/auth/sessions_spec.rb
@@ -68,4 +68,40 @@ RSpec.describe "Api::V1::Auth::Registrations", type: :request do
       end
     end
   end
+
+  describe "DELETE /api/v1/users/sing_in" do
+    subject { delete(destroy_api_v1_user_session_path, headers:) }
+
+    context "適切なパラメータが送信されたとき" do
+      let(:user) { create(:user) }
+      let!(:headers) { user.create_new_auth_token }
+      it "ログアウトができる" do
+        expect(headers).to be_present
+        expect { subject }.to change { user.reload.tokens.present? }.from(true).to(false)
+        res = JSON.parse(response.body)
+        expect(response).to have_http_status(:ok)
+        expect(res["success"]).to eq true
+      end
+    end
+
+    context "token情報が違う時" do
+      let(:user) { create(:user) }
+      let!(:headers) {
+        { "access-token" => "1111",
+          "token-type" => "kbndk",
+          "client" => "rrrr",
+          "expiry" => "35353",
+          "uid" => "222",
+          "authorization" => "" }
+      }
+      it "ログアウトが失敗する" do
+        expect(headers).to be_present
+        subject
+        res = JSON.parse(response.body)
+        expect(res["success"]).to eq false
+        expect(res["errors"][0]).to eq "User was not found or was not logged in."
+        expect(response).to have_http_status(:not_found) # ログアウト後のレスポンスステータスを確認
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 概要
表題の通りです。

## 内容

### config/application.rb
以下のエラー対処のために記述。
エラー対処をググって出てきた対処法で解消しました。
```
ActionDispatch::Request::Session::DisabledSessionError:
       Your application has sessions disabled. To write to the session you must first configure a session store
```

Railsのセッションを管理する設定を指定。

 `config.session_store :cookie_store, key: '_interslice_session'`  は、セッション情報を保存する場所としてクッキーを使うよう指定。
そのセッションの識別子として `_interslice_session` という名前を使用。

`config.middleware.use ActionDispatch::Cookies`  は、Railsがクッキーを読み書きするために使うミドルウェア（働き手） `ActionDispatch::Cookies` を使用するように設定。

`config.middleware.use config.session_store, config.session_options`  は、セッションとして設定したクッキーストアをミドルウェアとして利用するように指定。

### spec/requests/api/v1/auth/sessions_spec.rb
以下のことをテストしております。

正常系
ログアウトが正常にできているかを確認しています。
具体的には
作成したtokenがログアウトのリクエスト後無くなっているかを確認しています。

異常系
誤ったtoken情報を送信した時、ログアウトが弾かれることを確認しています。

