### PR TITLE
day_articleのテストのモック部分を削除、devise-token-authの機能を使って認証するよう修正

### DIFF
--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,6 +1,5 @@
 class Api::V1::BaseApiController < ApplicationController
-  ## 仮の実装、モック
-  def current_user
-    @current_user = User.first
-  end
+  alias_method :current_user, :current_api_v1_user
+  alias_method :authenticate_user!, :authenticate_api_v1_user!
+  alias_method :user_signed_in?, :api_v1_user_signed_in?
 end

--- a/app/controllers/api/v1/day_articles_controller.rb
+++ b/app/controllers/api/v1/day_articles_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::DayArticlesController < Api::V1::BaseApiController
+  before_action :authenticate_user!
+
   def index
     day_articles = DayArticle.all
     render json: day_articles

--- a/spec/requests/api/v1/day_articles_spec.rb
+++ b/spec/requests/api/v1/day_articles_spec.rb
@@ -2,7 +2,8 @@ require "rails_helper"
 
 RSpec.describe "Api::V1::DayArticles", type: :request do
   describe "GET /index" do
-    subject { get(api_v1_day_articles_path,headers:) }
+    subject { get(api_v1_day_articles_path, headers:) }
+
     let!(:user) { create(:user) }
     let!(:headers) { user.create_new_auth_token }
 
@@ -12,11 +13,11 @@ RSpec.describe "Api::V1::DayArticles", type: :request do
         subject
       end
 
-      fit "httpステータスが正常である" do
+      it "httpステータスが正常である" do
         expect(response).to have_http_status(:ok)
       end
 
-      fit "一覧を取得できる" do
+      it "一覧を取得できる" do
         res = JSON.parse(response.body)
         expect(res.length).to eq 3
       end
@@ -26,7 +27,7 @@ RSpec.describe "Api::V1::DayArticles", type: :request do
         expect(res[0].keys).to eq ["id", "body", "day", "updated_at", "user_id", "user"]
       end
 
-      fit "関連づけられたuserのserializerが適用されている" do
+      it "関連づけられたuserのserializerが適用されている" do
         res = JSON.parse(response.body)
         expect(res[0]["user"].keys).to eq ["id", "name", "email", "updated_at"]
       end
@@ -34,9 +35,9 @@ RSpec.describe "Api::V1::DayArticles", type: :request do
   end
 
   describe "GET/show" do
-    subject { get(api_v1_day_article_path(day_article_id),headers:) }
+    subject { get(api_v1_day_article_path(day_article_id), headers:) }
 
-    let(:day_article) { create(:day_article,user:) }
+    let(:day_article) { create(:day_article, user:) }
     let!(:user) { create(:user) }
     let!(:headers) { user.create_new_auth_token }
 
@@ -46,11 +47,11 @@ RSpec.describe "Api::V1::DayArticles", type: :request do
         subject
       end
 
-      fit "httpステータスが正常である" do
+      it "httpステータスが正常である" do
         expect(response).to have_http_status(:ok)
       end
 
-      fit "詳細を取得できる" do
+      it "詳細を取得できる" do
         res = JSON.parse(response.body)
 
         expect(res.length).to eq 6
@@ -67,21 +68,21 @@ RSpec.describe "Api::V1::DayArticles", type: :request do
     context "/api/v1/day_articles/:idのルートの時(誤った値)" do
       let(:day_article_id) { 99_999_999 }
 
-      fit "httpステータスがエラーが返ってくる" do
+      it "httpステータスがエラーが返ってくる" do
         expect { subject }.to raise_error ActiveRecord::RecordNotFound
       end
     end
   end
 
   describe "POST/create" do
-    subject { post(api_v1_day_articles_path, params: day_articles_params,headers:) }
+    subject { post(api_v1_day_articles_path, params: day_articles_params, headers:) }
 
     let!(:user) { create(:user) }
     let!(:headers) { user.create_new_auth_token }
 
     context "ログインユーザーの時、適切なパラメータをもとに記事が作成される" do
       let(:day_articles_params) { { day_article: attributes_for(:day_article) } }
-      fit "現在のユーザをもとに記事が作成できる" do
+      it "現在のユーザをもとに記事が作成できる" do
         subject
         res = JSON.parse(response.body)
         expect(DayArticle.last.user_id).to eq(user.id)
@@ -93,23 +94,23 @@ RSpec.describe "Api::V1::DayArticles", type: :request do
 
     context "正しくないパラメータでリクエストを送った時" do
       let(:day_articles_params) { attributes_for(:day_article) }
-      fit "エラーになる" do
+      it "エラーになる" do
         expect { subject }.to raise_error ActionController::ParameterMissing
       end
     end
   end
 
   describe "PUT /update" do
-    subject { put(api_v1_day_article_path(day_article), params: day_articles_params,headers:) }
+    subject { put(api_v1_day_article_path(day_article), params: day_articles_params, headers:) }
 
-    let!(:day_article) { create(:day_article, user: ) }
+    let!(:day_article) { create(:day_article, user:) }
     let!(:user) { create(:user) }
     let!(:headers) { user.create_new_auth_token }
 
     context "ログインユーザーの時、適切なパラメータをもとに記事が更新される" do
       let(:day_articles_params) { { day_article: { body: "新しいテキスト" } } }
 
-      fit "現在のユーザをもとに記事が更新できる" do
+      it "現在のユーザをもとに記事が更新できる" do
         subject
         res = JSON.parse(response.body)
         expect(response).to have_http_status(:ok)
@@ -120,21 +121,21 @@ RSpec.describe "Api::V1::DayArticles", type: :request do
 
     context "不適切なパラメータでリクエストを送った時" do
       let(:day_articles_params) { { title: "新しいタイトル" } } # paramsの形式がおかしい
-      fit "エラーになる" do
+      it "エラーになる" do
         expect { subject }.to raise_error ActionController::ParameterMissing
       end
     end
   end
 
   describe "DELETE /destroy" do
-    subject { delete(api_v1_day_article_path(day_article),headers:) }
+    subject { delete(api_v1_day_article_path(day_article), headers:) }
 
-    let!(:day_article) { create(:day_article, user: ) }
+    let!(:day_article) { create(:day_article, user:) }
     let(:user) { create(:user) }
     let!(:headers) { user.create_new_auth_token }
 
     context "ログインユーザーの場合、記事が削除される" do
-      fit "現在のユーザをもとに記事が削除される" do
+      it "現在のユーザをもとに記事が削除される" do
         # リクエストを送信
         subject
         # HTTPステータスが正常なことを検証　204-deleteやput時に返ってくることのあるステータスz


### PR DESCRIPTION
## 概要
表題の通りです。
関連して、数ファイルの修正を行いました。

## 内容

### app/controllers/api/v1/base_api_controller.rb
api_v1_をつけた名称でなく呼び出せるようにしております。

### app/controllers/api/v1/day_articles_controller.rb
今アプリでは外部からの一覧表示、詳細表示を想定していないため全ての機能でuserの認証を確認しています。

### spec/requests/api/v1/day_articles_spec.rb
モック部分は削除。

他の部分はログインしたユーザーが行うようにコードを修正しております。