### PR TITLE
habitsコントローラの機能追加、テストの作成

### DIFF
--- a/app/controllers/api/v1/habits_controller.rb
+++ b/app/controllers/api/v1/habits_controller.rb
@@ -1,6 +1,45 @@
-class Api::V1::HabitsController < ApplicationController
+class Api::V1::HabitsController < Api::V1::BaseApiController
+  before_action :authenticate_user!
+
   def index
     habits = Habit.all
     render json: habits
+    # ,each_serializer: HabitSerializer
   end
+
+  def create
+    habit = current_user.habits.build(habit_params)
+    if habit.save
+      render json: habit, status: :created
+    else
+      render json: habit.errors, status: :unprocessable_entity
+    end
+  end
+
+  def show
+    habit = Habit.find(params[:id])
+    render json: habit
+  end
+
+  def update
+    habit = current_user.habits.find(params[:id])
+    if habit.update(habit_params)
+      render json: habit
+    else
+      render json: habit.errors, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    habit = current_user.habits.find(params[:id])
+    habit.destroy!
+    head :no_content
+  end
+
+  private
+
+    # Storong Parameter
+    def habit_params
+      params.require(:habit).permit(:start_date, :name)
+    end
 end

--- a/spec/requests/api/v1/habit_spec.rb
+++ b/spec/requests/api/v1/habit_spec.rb
@@ -2,16 +2,146 @@ require "rails_helper"
 
 RSpec.describe "Api::V1::Habits", type: :request do
   describe "GET /index" do
-    subject { get(api_v1_habits_path) }
+    subject { get(api_v1_habits_path, headers:) }
+
+    let!(:user) { create(:user) }
+    let!(:headers) { user.create_new_auth_token }
 
     context "/api/v1/habitsのルートの時" do
       before do
-        create_list(:habit, 3)
+        create_list(:habit, 3, user:)
         subject
       end
 
       it "httpステータスが正常である" do
         expect(response).to have_http_status(:ok)
+      end
+
+      it "一覧を取得できる" do
+        res = JSON.parse(response.body)
+        expect(res.length).to eq 3
+      end
+
+      it "想定したkeyが帰ってきている" do
+        res = JSON.parse(response.body)
+        expect(res[0].keys).to eq ["id", "name", "start_date", "updated_at", "user_id", "user"]
+      end
+
+      it "関連づけられたuserのserializerが適用されている" do
+        res = JSON.parse(response.body)
+        expect(res[0]["user"].keys).to eq ["id", "name", "email", "updated_at"]
+      end
+    end
+  end
+
+  describe "GET/show" do
+    subject { get(api_v1_habit_path(habit_id), headers:) }
+
+    let(:habit) { create(:habit, user:) }
+    let!(:user) { create(:user) }
+    let!(:headers) { user.create_new_auth_token }
+
+    context "/api/v1/habits/:idのルートの時(正しい値)" do
+      let(:habit_id) { habit.id }
+      before do
+        subject
+      end
+
+      it "httpステータスが正常である" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "詳細を取得できる" do
+        res = JSON.parse(response.body)
+
+        expect(res.length).to eq 6
+        expect(res.keys).to eq ["id", "name", "start_date", "updated_at", "user_id", "user"]
+        expect(res["id"]).to eq habit.id
+        expect(res["name"]).to eq habit.name
+        expect(res["start_date"]).to eq habit.start_date.strftime("%Y-%m-%d")
+        expect(res["updated_at"]).to be_present
+        expect(res["user_id"]).to eq habit.user_id
+        expect(res["user"].keys).to eq ["id", "name", "email", "updated_at"]
+      end
+    end
+
+    context "/api/v1/habits/:idのルートの時(誤った値)" do
+      let(:habit_id) { 99_999_999 }
+
+      it "httpステータスがエラーが返ってくる" do
+        expect { subject }.to raise_error ActiveRecord::RecordNotFound
+      end
+    end
+  end
+
+  describe "POST/create" do
+    subject { post(api_v1_habits_path, params: habits_params, headers:) }
+
+    let!(:user) { create(:user) }
+    let!(:headers) { user.create_new_auth_token }
+
+    context "ログインユーザーの時、適切なパラメータをもとに記事が作成される" do
+      let(:habits_params) { { habit: attributes_for(:habit) } }
+      it "現在のユーザをもとに記事が作成できる" do
+        subject
+        res = JSON.parse(response.body)
+        expect(Habit.last.user_id).to eq(user.id)
+        expect(response).to have_http_status(:created)
+        expect(res["start_date"]).to eq habits_params[:habit][:start_date].strftime("%Y-%m-%d")
+        expect(res["name"]).to eq habits_params[:habit][:name]
+      end
+    end
+
+    context "正しくないパラメータでリクエストを送った時" do
+      let(:habits_params) { attributes_for(:habit) }
+      it "エラーになる" do
+        expect { subject }.to raise_error ActionController::ParameterMissing
+      end
+    end
+  end
+
+  describe "PUT /update" do
+    subject { put(api_v1_habit_path(habit), params: habits_params, headers:) }
+
+    let!(:habit) { create(:habit, user:) }
+    let!(:user) { create(:user) }
+    let!(:headers) { user.create_new_auth_token }
+
+    context "ログインユーザーの時、適切なパラメータをもとに記事が更新される" do
+      let(:habits_params) { { habit: { body: "新しいテキスト" } } }
+
+      it "現在のユーザをもとに記事が更新できる" do
+        subject
+        res = JSON.parse(response.body)
+        expect(response).to have_http_status(:ok)
+        expect(habit.name).not_to eq "新しいテキスト"
+        expect(res["body"]).to eq "新しいテキスト"
+      end
+    end
+
+    context "不適切なパラメータでリクエストを送った時" do
+      let(:habits_params) { { title: "新しいタイトル" } } # paramsの形式がおかしい
+      it "エラーになる" do
+        expect { subject }.to raise_error ActionController::ParameterMissing
+      end
+    end
+  end
+
+  describe "DELETE /destroy" do
+    subject { delete(api_v1_habit_path(habit), headers:) }
+
+    let!(:habit) { create(:habit, user:) }
+    let(:user) { create(:user) }
+    let!(:headers) { user.create_new_auth_token }
+
+    context "ログインユーザーの場合、記事が削除される" do
+      it "現在のユーザをもとに記事が削除される" do
+        # リクエストを送信
+        subject
+        # HTTPステータスが正常なことを検証　204-deleteやput時に返ってくることのあるステータスz
+        expect(response).to have_http_status(:no_content)
+        # データベース上で記事が削除されたことを検証
+        expect(Habit.find_by(id: habit.id)).to be_nil
       end
     end
   end

--- a/spec/requests/api/v1/habit_spec.rb
+++ b/spec/requests/api/v1/habit_spec.rb
@@ -108,19 +108,19 @@ RSpec.describe "Api::V1::Habits", type: :request do
     let!(:headers) { user.create_new_auth_token }
 
     context "ログインユーザーの時、適切なパラメータをもとに記事が更新される" do
-      let(:habits_params) { { habit: { body: "新しいテキスト" } } }
+      let(:habits_params) { { habit: { name: "新しい名前" } } }
 
       it "現在のユーザをもとに記事が更新できる" do
         subject
         res = JSON.parse(response.body)
         expect(response).to have_http_status(:ok)
-        expect(habit.name).not_to eq "新しいテキスト"
-        expect(res["body"]).to eq "新しいテキスト"
+        expect(habit.name).not_to eq "新しい名前"
+        expect(res["name"]).to eq "新しい名前"
       end
     end
 
     context "不適切なパラメータでリクエストを送った時" do
-      let(:habits_params) { { title: "新しいタイトル" } } # paramsの形式がおかしい
+      let(:habits_params) { { name: "新しい名前" } } # paramsの形式がおかしい
       it "エラーになる" do
         expect { subject }.to raise_error ActionController::ParameterMissing
       end


### PR DESCRIPTION
## 概要
表題の通り、habitsコントローラの機能追加し、テストの作成を行いました。

## 内容
### app/controllers/api/v1/habits_controller.rb
day_articlesの内容を参考に作成しています。

今回はログインユーザー以外情報は見れない設定なので全あくしょんにおいてユーザーがログイン状態かどうかの確認を行なっております。

### spec/requests/api/v1/habit_spec.rb
day_articlesのテストを参考に作成しております。

index
・一覧を取得できる
・想定したkeyが帰ってきている
・関連づけられたuserのserializerが適用されている

show
・正しいhttpコードが返っててきていることを確認しています。
・詳細情報が取得できることを確認しています。
・誤った値の時、エラーが返ってくることを確認しています。

create
・day_articleレコードがcurrent_userを元に作成できるを確認しています。
・パラメータが間違っている時、エラーが起きるを確認しています。

update
・レコードが更新されることを確認しています。
・parameterが適切な形でない場合、エラーが起きることを確認しています。

destroy
・リクエストを送り、送信後、データが削除されていることを確認しています。
・ステータスは204,no_contentをなことを確認しています。