### PR TITLE
monthly_articleのコントローラindex~destroyまで作成、requset_specも作成

### DIFF
--- a/app/controllers/api/v1/monthly_articles_controller.rb
+++ b/app/controllers/api/v1/monthly_articles_controller.rb
@@ -1,6 +1,44 @@
 class Api::V1::MonthlyArticlesController < Api::V1::BaseApiController
+  before_action :authenticate_user!
+
   def index
     monthly_articles = MonthlyArticle.all
     render json: monthly_articles
   end
+
+  def create
+    monthly_article = current_user.monthly_articles.build(monthly_article_params)
+    if monthly_article.save
+      render json: monthly_article, status: :created
+    else
+      render json: monthly_article.errors, status: :unprocessable_entity
+    end
+  end
+
+  def show
+    monthly_article = MonthlyArticle.find(params[:id])
+    render json: monthly_article
+  end
+
+  def update
+    monthly_article = current_user.monthly_articles.find(params[:id])
+    if monthly_article.update(monthly_article_params)
+      render json: monthly_article
+    else
+      render json: monthly_article.errors, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    monthly_article = current_user.monthly_articles.find(params[:id])
+    monthly_article.destroy!
+    head :no_content
+  end
+
+  private
+
+    # Storong Parameter
+    def monthly_article_params
+      params.require(:monthly_article).permit(:beginning_of_month, :body)
+    end
 end

--- a/spec/requests/api/v1/monthly_article_spec.rb
+++ b/spec/requests/api/v1/monthly_article_spec.rb
@@ -2,18 +2,148 @@ require "rails_helper"
 
 RSpec.describe "Api::V1::MonthlyArticles", type: :request do
   describe "GET /index" do
-    subject { get(api_v1_monthly_articles_path) }
+    subject { get(api_v1_monthly_articles_path, headers:) }
+
+    let!(:user) { create(:user) }
+    let!(:headers) { user.create_new_auth_token }
 
     context "/api/v1/monthly_articlesのルートの時" do
       before do
         3.times do |n|
-          create(:monthly_article, beginning_of_month: "2022-#{1 + n}-1")
+          create(:monthly_article, beginning_of_month: "2022-#{1 + n}-1", user:)
         end
         subject
       end
 
       it "httpステータスが正常である" do
         expect(response).to have_http_status(:ok)
+      end
+
+      it "一覧を取得できる" do
+        res = JSON.parse(response.body)
+        expect(res.length).to eq 3
+      end
+
+      it "想定したkeyが帰ってきている" do
+        res = JSON.parse(response.body)
+        expect(res[0].keys).to eq ["id", "beginning_of_month", "body", "updated_at", "user_id", "user"]
+      end
+
+      it "関連づけられたuserのserializerが適用されている" do
+        res = JSON.parse(response.body)
+        expect(res[0]["user"].keys).to eq ["id", "name", "email", "updated_at"]
+      end
+    end
+  end
+
+  describe "GET/show" do
+    subject { get(api_v1_monthly_article_path(monthly_article_id), headers:) }
+
+    let(:monthly_article) { create(:monthly_article, user:) }
+    let!(:user) { create(:user) }
+    let!(:headers) { user.create_new_auth_token }
+
+    context "/api/v1/monthly_articles/:idのルートの時(正しい値)" do
+      let(:monthly_article_id) { monthly_article.id }
+      before do
+        subject
+      end
+
+      it "httpステータスが正常である" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "詳細を取得できる" do
+        res = JSON.parse(response.body)
+
+        expect(res.length).to eq 6
+        expect(res.keys).to eq ["id", "beginning_of_month", "body", "updated_at", "user_id", "user"]
+        expect(res["id"]).to eq monthly_article.id
+        expect(res["body"]).to eq monthly_article.body
+        expect(res["beginning_of_month"]).to eq monthly_article.beginning_of_month.strftime("%Y-%m-%d")
+        expect(res["updated_at"]).to be_present
+        expect(res["user_id"]).to eq monthly_article.user_id
+        expect(res["user"].keys).to eq ["id", "name", "email", "updated_at"]
+      end
+    end
+
+    context "/api/v1/monthly_articles/:idのルートの時(誤った値)" do
+      let(:monthly_article_id) { 99_999_999 }
+
+      it "httpステータスがエラーが返ってくる" do
+        expect { subject }.to raise_error ActiveRecord::RecordNotFound
+      end
+    end
+  end
+
+  describe "POST/create" do
+    subject { post(api_v1_monthly_articles_path, params: monthly_articles_params, headers:) }
+
+    let!(:user) { create(:user) }
+    let!(:headers) { user.create_new_auth_token }
+
+    context "ログインユーザーの時、適切なパラメータをもとに記事が作成される" do
+      let(:monthly_articles_params) { { monthly_article: attributes_for(:monthly_article) } }
+      it "現在のユーザをもとに記事が作成できる" do
+        subject
+        res = JSON.parse(response.body)
+        expect(MonthlyArticle.last.user_id).to eq(user.id)
+        expect(response).to have_http_status(:created)
+        expect(res["beginning_of_month"]).to eq monthly_articles_params[:monthly_article][:beginning_of_month].strftime("%Y-%m-%d")
+        expect(res["body"]).to eq monthly_articles_params[:monthly_article][:body]
+      end
+    end
+
+    context "正しくないパラメータでリクエストを送った時" do
+      let(:monthly_articles_params) { attributes_for(:monthly_article) }
+      it "エラーになる" do
+        expect { subject }.to raise_error ActionController::ParameterMissing
+      end
+    end
+  end
+
+  describe "PUT /update" do
+    subject { put(api_v1_monthly_article_path(monthly_article), params: monthly_articles_params, headers:) }
+
+    let!(:monthly_article) { create(:monthly_article, user:) }
+    let!(:user) { create(:user) }
+    let!(:headers) { user.create_new_auth_token }
+
+    context "ログインユーザーの時、適切なパラメータをもとに記事が更新される" do
+      let(:monthly_articles_params) { { monthly_article: { body: "新しいテキスト" } } }
+
+      it "現在のユーザをもとに記事が更新できる" do
+        subject
+        res = JSON.parse(response.body)
+        expect(response).to have_http_status(:ok)
+        expect(monthly_article.body).not_to eq "新しいテキスト"
+        expect(res["body"]).to eq "新しいテキスト"
+      end
+    end
+
+    context "不適切なパラメータでリクエストを送った時" do
+      let(:monthly_articles_params) { { title: "新しいタイトル" } } # paramsの形式がおかしい
+      it "エラーになる" do
+        expect { subject }.to raise_error ActionController::ParameterMissing
+      end
+    end
+  end
+
+  describe "DELETE /destroy" do
+    subject { delete(api_v1_monthly_article_path(monthly_article), headers:) }
+
+    let!(:monthly_article) { create(:monthly_article, user:) }
+    let(:user) { create(:user) }
+    let!(:headers) { user.create_new_auth_token }
+
+    context "ログインユーザーの場合、記事が削除される" do
+      it "現在のユーザをもとに記事が削除される" do
+        # リクエストを送信
+        subject
+        # HTTPステータスが正常なことを検証　204-deleteやput時に返ってくることのあるステータスz
+        expect(response).to have_http_status(:no_content)
+        # データベース上で記事が削除されたことを検証
+        expect(DayArticle.find_by(id: monthly_article.id)).to be_nil
       end
     end
   end


### PR DESCRIPTION
## 概要
表題の通りです

## 内容
### spec/requests/api/v1/monthly_article_spec.rb
以下の内容をテストしています。

index
正常系
・httpステータスが正常である
・一覧を取得できる
・想定したkeyが帰ってきている
・関連づけられたuserのserializerが適用されている

show
正常系
・httpステータスが正常である
・詳細が取得できている
異常系
・誤った、paramsの時、httpステータスがエラーが返ってくる

create
正常系
・現在のユーザをもとに記事が作成できる
異常系
・正しくないパラメータでリクエストを送った時エラーになる

update
正常系
・現在のユーザをもとに記事が更新できる
異常系
・正しくないパラメータでリクエストを送った時エラーになる

destroy
・ログインユーザーの場合記事が削除される

### app/controllers/api/v1/monthly_articles_controller.rb
day_articlesとほぼ同内容で、strong_parameterだけDBのカラム名に合わせたものに変更しています。
CRUD処理のアクションを書いています。